### PR TITLE
Add more things (untested)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,17 +3,20 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - "master"
 
 jobs:
   simple-build:
     strategy:
       matrix:
-        os: [ubuntu-latest] # macos not yet populated
-    runs-on: ${{ matrix.os }}
+        os: ["ubuntu-latest"] # macos not yet populated
+    runs-on: "${{ matrix.os }}"
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Nix
-      uses: cachix/install-nix-action@v17
-    - name: Install Flox
-      uses: ./
+      - uses: "actions/checkout@v3"
+      - name: "Install flox"
+        uses: "./"
+        with:
+          cache-key: "install-flox-action-test"
+
+      - shell: "bash"
+        run: "save-built"

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,79 @@
-name: 'Install Flox'
-description: 'Installs Flox on GitHub Actions for the supported platforms: Linux and macOS.'
-author: 'Yannik Sander'
+name: "Install flox"
+description: "Installs flox on GitHub Actions for the supported platforms: GNU/Linux and macOS."
+author: "flox"
+
 branding:
-  color: 'blue'
-  icon: 'moon'
+  color: "blue"
+  icon: "moon"
+
+inputs:
+  github-access-token:
+    description: "GitHub access token to use when using the GitHub fetcher"
+  ssh-key:
+    description: "SSH key to use when fetching over SSH"
+  ssh-key-format:
+    description: "Format of ssh-key or format to generate"
+    default: "ed25519"
+  ssh-auth-sock:
+    description: "Used to set SSH_AUTH_SOCK variable, used by some Nix fetchers"
+  cache-key:
+    description: "Cache key to use for retaining the Nix store"
+  existing-nix:
+    description: "If we should utilize the pre-installed Nix instead of adding our own"
+
 runs:
-  using: 'composite'
+  using: "composite"
+
   steps:
-    - run : ${{ github.action_path }}/install-flox.sh
-      shell: bash
+    - uses: "cachix/install-nix-action@v20"
+      if: "inputs.existing_nix != 'true'"
+      with:
+        github_access_token: "${{ inputs.github-access-token }}"
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          max-jobs = auto
+          cores = 0
+          builders-use-substitutes = true
+          fallback = true
+          connect-timeout = 5
+          stalled-download-timeout = 90
+
+    - name: "Fix Nix credentials"
+      shell: "bash"
+      run: "${{ github.action_path }}/fix-nix-credentials.sh"
+      env:
+        INPUTS_SSH_KEY_FORMAT: "${{ inputs.ssh-key-format }}"
+        INPUTS_SSH_KEY: "${{ inputs.ssh-key }}"
+        INPUTS_SSH_AUTH_SOCK: "${{ inputs.ssh-auth-sock }}"
+        INPUTS_GITHUB_ACCESS_TOKEN: "${{ inputs.github-access-token }}"
+
+
+    - name: "Create Nix store cache"
+      uses: "actions/cache@v3.0.8"
+      id: "nix-cache"
+      if: "inputs.cache-key != ''"
+      with:
+        path: "/tmp/nixcache"
+        key: "${{ inputs.cache-key }}"
+
+    - name: "Import Nix store cache"
+      if: "steps.nix-cache.outputs.cache-hit == 'true'"
+      shell: "bash"
+      run: |
+        nix-store --import < /tmp/nixcache
+
+    - name: "Install flox"
+      shell: "bash"
+      run: "${{ github.action_path }}/install-flox.sh"
+
+    - name: "Enable exporting Nix store to cache"
+      if: "inputs.cache-key != ''"
+      shell: "bash"
+      run: |
+        echo "post-build-hook = ${{ github.action_path }}/write-built.sh" | sudo tee -a /etc/nix/nix.conf
+        mkdir -p "$HOME/.local/bin"
+        cp '${{ github.action_path }}/save-built.sh' "$HOME/.local/bin/save-built"
+        echo "PATH='$PATH:$HOME/.local/bin'" > "$GITHUB_ENV"
+
+        # Run this at the start to make sure the cache works, and to get flox itself cached
+        ${{ github.action_path }}/save-built.sh

--- a/fix-nix-credentials.sh
+++ b/fix-nix-credentials.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GitHub command to put the following log messages into a group which is collapsed by default
+echo "::group::Fixing Nix credential issues"
+
+# Allows `builtins.fetchGit' and related to work.
+mkdir -p "$HOME/.ssh"
+ssh-keyscan github.com >> "$HOME/.ssh/known_hosts"
+
+if [ -z "$INPUTS_SSH_KEY" ]; then
+  ssh-keygen -q -N '' -t "$INPUTS_SSH_KEY_FORMAT" -f "$HOME/.ssh/id_$INPUTS_SSH_KEY_FORMAT"
+else
+  touch "$HOME/.ssh/id_$INPUTS_SSH_KEY_FORMAT"
+  chmod 600 "$HOME/.ssh/id_$INPUTS_SSH_KEY_FORMAT"
+  echo "$INPUTS_SSH_KEY" > "$HOME/.ssh/id_$INPUTS_SSH_KEY_FORMAT"
+  ssh-keygen -f "$HOME/.ssh/id_$INPUTS_SSH_KEY_FORMAT" -y > "$HOME/.ssh/id_$INPUTS_SSH_KEY_FORMAT.pub"
+fi
+
+if [ -n "$INPUTS_SSH_AUTH_SOCK" ]; then
+  SSH_AUTH_SOCK="$INPUTS_SSH_AUTH_SOCK"
+fi
+
+eval "$(ssh-agent)"
+echo "SSH_AUTH_SOCK='$SSH_AUTH_SOCK'" > "$GITHUB_ENV"
+echo "SSH_AGENT_PID='$SSH_AGENT_PID'" > "$GITHUB_ENV"
+
+git config --global user.email || git config --global user.email "floxuser@example.invalid"
+git config --global user.name || git config --global user.name "flox User"
+
+# Allows `builtins.fetch{url,Tarball}' and related to work:
+mkdir -p "$HOME/.config/nix";
+echo "machine api.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" > "$HOME/.config/nix/netrc"
+echo "machine pkgs.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.config/nix/netrc"
+echo "machine github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.config/nix/netrc"
+
+# Close the log message group which was opened above
+echo "::endgroup::"

--- a/install-flox.sh
+++ b/install-flox.sh
@@ -9,14 +9,10 @@ fi
 # GitHub command to put the following log messages into a group which is collapsed by default
 echo "::group::Installing Flox"
 
-# [sic] Remove access-token after closed beta
-nix --extra-experimental-features "flakes nix-command" \
-    --access-tokens "github.com=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" \
-    profile install \
-    --impure \
-    --accept-flake-config \
-    "github:flox/floxpkgs#evalCatalog.$(nix eval --expr  'builtins.currentSystem' --impure).stable.floxpkgs.flox"
-
+nix profile install --impure \
+      --experimental-features "nix-command flakes" \
+      --accept-flake-config \
+      'github:flox/floxpkgs#flox.fromCatalog'
 
 # Close the log message group which was opened above
 echo "::endgroup::"

--- a/save-built.sh
+++ b/save-built.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# We want to save flox itself always, and ensure the file exists
+echo "$(readlink -f "$(which flox)")" >> /tmp/built-derivations
+
+echo "Deduplicating built derivations"
+LINES="$(cat /tmp/built-derivations)"
+echo "$LINES" | sort | uniq | sed '/^$/d' > /tmp/built-derivations
+
+echo "Using these built paths:"
+cat /tmp/built-derivations
+
+echo "Collecting dependencies..."
+
+ALL_PATHS=()
+
+while read -r BUILT_OUT_PATH; do
+    ALL_PATHS+=("$BUILT_OUT_PATH")
+    while read DEP_PATH; do
+        ALL_PATHS+=("$DEP_PATH")
+    done < <(nix-store -qR "$BUILT_OUT_PATH")
+done < /tmp/built-derivations
+
+echo "Saving these paths to the cache:"
+echo "${ALL_PATHS[@]}"
+
+nix-store --export "${ALL_PATHS[@]}" > /tmp/nixcache

--- a/write-built.sh
+++ b/write-built.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -f
+
+export IFS=' '
+
+for OUT_PATH in "$OUT_PATHS"; do
+    echo "$OUT_PATH" >> /tmp/built-derivations
+done


### PR DESCRIPTION
I think we can now have internal `uses` steps, so lets install Nix too, add some fancy credentials stff (thanks @aakropotkin), and cache builds