### PR TITLE
Use correct git tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install flox
-      uses: flox/install-flox-action@v1
+      uses: flox/install-flox-action@v1.0.0
 
     - name: Build
       run: flox build


### PR DESCRIPTION
When a user now follows the README, the action will complain that it didn't find the v1 tag. Either we fix the README, or make sure there's also a tag for the latest major version.