### PR TITLE
Add profile path to PATH

### DIFF
--- a/install-flox.sh
+++ b/install-flox.sh
@@ -14,6 +14,9 @@ nix profile install --impure \
       --accept-flake-config \
       'github:flox/floxpkgs#flox.fromCatalog'
 
+# This may not already be included if Nix didn't come from install-nix-action
+echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"
+
 # Close the log message group which was opened above
 echo "::endgroup::"
 

--- a/install-flox.sh
+++ b/install-flox.sh
@@ -14,10 +14,12 @@ nix profile install --impure \
       --accept-flake-config \
       'github:flox/floxpkgs#flox.fromCatalog'
 
+# Check it runs
+$HOME/.nix-profile/bin/flox --version
+
 # This may not already be included if Nix didn't come from install-nix-action
 echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"
 
 # Close the log message group which was opened above
 echo "::endgroup::"
 
-flox --version

--- a/install-flox.sh
+++ b/install-flox.sh
@@ -17,7 +17,9 @@ nix profile install --impure \
 # Check it runs
 $HOME/.nix-profile/bin/flox --version
 
-# This may not already be included if Nix didn't come from install-nix-action
+# This might already be set e.g. if Nix was installed using install-nix-action.
+# If Nix was already installed through other means (e.g. on a hosted runner)
+# this path might be missing, so we include it to be safe.
 echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"
 
 # Close the log message group which was opened above


### PR DESCRIPTION
`$HOME/.nix-profile/bin` already be included in the `PATH` e.g. if Nix was installed using install-nix-action.
If Nix was already installed through other means (e.g. on a hosted runner),
this path might be missing.
To be safe, we include it here (possibly for a second time)