### PR TITLE
Fix `.netrc` path

### DIFF
--- a/fix-nix-credentials.sh
+++ b/fix-nix-credentials.sh
@@ -31,7 +31,7 @@ git config --global user.name || git config --global user.name "flox User"
 
 # Allows `builtins.fetch{url,Tarball}' and related to work:
 mkdir -p "$HOME/.config/nix";
-echo "machine api.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" > "$HOME/.netrc";
+echo "machine api.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.netrc";
 echo "machine pkgs.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.netrc";
 echo "machine github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.netrc";
 ln -sr "$HOME/.netrc" "$HOME/.config/nix/netrc";

--- a/fix-nix-credentials.sh
+++ b/fix-nix-credentials.sh
@@ -31,9 +31,10 @@ git config --global user.name || git config --global user.name "flox User"
 
 # Allows `builtins.fetch{url,Tarball}' and related to work:
 mkdir -p "$HOME/.config/nix";
-echo "machine api.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" > "$HOME/..netrc"
-echo "machine pkgs.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.netrc"
-echo "machine github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.netrc"
+echo "machine api.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" > "$HOME/.netrc";
+echo "machine pkgs.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.netrc";
+echo "machine github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.netrc";
+ln -sr "$HOME/.netrc" "$HOME/.config/nix/netrc";
 
 # Close the log message group which was opened above
 echo "::endgroup::"

--- a/fix-nix-credentials.sh
+++ b/fix-nix-credentials.sh
@@ -31,9 +31,9 @@ git config --global user.name || git config --global user.name "flox User"
 
 # Allows `builtins.fetch{url,Tarball}' and related to work:
 mkdir -p "$HOME/.config/nix";
-echo "machine api.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" > "$HOME/.config/nix/netrc"
-echo "machine pkgs.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.config/nix/netrc"
-echo "machine github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.config/nix/netrc"
+echo "machine api.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" > "$HOME/..netrc"
+echo "machine pkgs.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.netrc"
+echo "machine github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.netrc"
 
 # Close the log message group which was opened above
 echo "::endgroup::"


### PR DESCRIPTION
Many builtin fetchers are hard coded to always refer to `$HOME/.netrc`. The file `$HOME/.config/nix/netrc` is only referenced by `nixpkgs#fetch*` routines ( I know this sounds like non-sense, but have faith - it took me ages to debug this last year ).