### PR TITLE
chore: use install-nix-action@22

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
   using: "composite"
 
   steps:
-    - uses: "cachix/install-nix-action@v21"
+    - uses: "cachix/install-nix-action@v22"
       if: "inputs.existing_nix != 'true'"
       with:
         github_access_token: "${{ inputs.github-access-token }}"


### PR DESCRIPTION
This pulls in a fix for https://github.com/cachix/install-nix-action/issues/183