### PR TITLE
feat: support macOS

### DIFF
--- a/.github/workflows/test-prerelease.yml
+++ b/.github/workflows/test-prerelease.yml
@@ -10,7 +10,7 @@ jobs:
   install-flox-pre-release:
     strategy:
       matrix:
-        os: ["ubuntu-latest"] # macos not yet populated
+        os: ["ubuntu-latest", "macos-latest"]
     runs-on: "${{ matrix.os }}"
     steps:
       - uses: "actions/checkout@v3"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   simple-build:
     strategy:
       matrix:
-        os: ["ubuntu-latest"] # macos not yet populated
+        os: ["ubuntu-latest", "macos-latest"]
     runs-on: "${{ matrix.os }}"
     steps:
       - uses: "actions/checkout@v3"
@@ -23,11 +23,11 @@ jobs:
         run: "save-built"
 
   simple-cache-test:
-    name: simple-build ${{ matrix.package }}
-    runs-on: ubuntu-latest
+    runs-on: "${{ matrix.os }}"
 
     strategy:
       matrix:
+        os: ["ubuntu-latest", "macos-latest"]
         include:
           - package: nixpkgs#hello
           - package: nixpkgs#jq

--- a/action.yml
+++ b/action.yml
@@ -117,7 +117,7 @@ runs:
         echo "post-build-hook = ${{ github.action_path }}/write-built.sh" | sudo tee -a /etc/nix/nix.conf
         mkdir -p "$HOME/.local/bin"
         cp '${{ github.action_path }}/save-built.sh' "$HOME/.local/bin/save-built"
-        echo "PATH='$PATH:$HOME/.local/bin'" > "$GITHUB_ENV"
+        echo "PATH=$PATH:$HOME/.local/bin" > "$GITHUB_ENV"
 
         # Run this at the start to make sure the cache works, and to get flox itself cached
         ${{ github.action_path }}/save-built.sh

--- a/configure-substituter.sh
+++ b/configure-substituter.sh
@@ -31,7 +31,15 @@ printf "%s\n" \
 
 echo "Restarting the Nix daemon"
 
-sudo systemctl daemon-reload
-sudo systemctl restart nix-daemon.service
+if [[ "$RUNNER_OS" == "Linux" ]]; then
+	sudo systemctl daemon-reload
+	sudo systemctl restart nix-daemon.service
+elif [[ "$RUNNER_OS" == "macOS" ]]; then
+	sudo launchctl stop org.nixos.nix-daemon
+	sudo launchctl start org.nixos.nix-daemon
+else
+	echo "Unsupported OS: $RUNNER_OS"
+	exit 1
+fi
 
 echo "::endgroup::"

--- a/fix-nix-credentials.sh
+++ b/fix-nix-credentials.sh
@@ -22,7 +22,7 @@ if [ -n "$INPUTS_SSH_AUTH_SOCK" ]; then
 fi
 
 nohup ssh-agent -D > .ssh-agent-out &
-eval "$(tail -f .ssh-agent-out | sed '/echo Agent pid/ q')"
+eval "$( (tail -f .ssh-agent-out &) | sed '/echo Agent pid/ q')"
 
 echo "SSH_AUTH_SOCK='$SSH_AUTH_SOCK'" > "$GITHUB_ENV"
 
@@ -34,7 +34,7 @@ mkdir -p "$HOME/.config/nix";
 echo "machine api.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.netrc";
 echo "machine pkgs.github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.netrc";
 echo "machine github.com password $INPUTS_GITHUB_ACCESS_TOKEN" >> "$HOME/.netrc";
-ln -sr "$HOME/.netrc" "$HOME/.config/nix/netrc";
+ln -s "$HOME/.netrc" "$HOME/.config/nix/netrc";
 
 # Close the log message group which was opened above
 echo "::endgroup::"


### PR DESCRIPTION
- enable macOS in action matrix
- fix tail hanging forever on macOS, because tail doesn't exit when the
  program it is piping to exits
- don't create relative symlink, because macOS ln doesn't support the -r
  option
- use launchctl on macOS instead of systemctl
- GitHub actions treates quotes literally for variables set in GITHUB_ENV,
  so don't put quotes in PATH. Literal quotes in PATH appear to break
  finding binaries on macOS