### PR TITLE
Kickstart daemon on OSX

### DIFF
--- a/configure-substituter.sh
+++ b/configure-substituter.sh
@@ -36,7 +36,7 @@ if [[ "$RUNNER_OS" == "Linux" ]]; then
 	sudo systemctl restart nix-daemon.service
 elif [[ "$RUNNER_OS" == "macOS" ]]; then
 	sudo launchctl stop org.nixos.nix-daemon
-	sudo launchctl start org.nixos.nix-daemon
+	sudo launchctl kickstart -k system/org.nixos.nix-daemon
 else
 	echo "Unsupported OS: $RUNNER_OS"
 	exit 1

--- a/configure-substituter.sh
+++ b/configure-substituter.sh
@@ -35,7 +35,6 @@ if [[ "$RUNNER_OS" == "Linux" ]]; then
 	sudo systemctl daemon-reload
 	sudo systemctl restart nix-daemon.service
 elif [[ "$RUNNER_OS" == "macOS" ]]; then
-	sudo launchctl stop org.nixos.nix-daemon
 	sudo launchctl kickstart -k system/org.nixos.nix-daemon
 else
 	echo "Unsupported OS: $RUNNER_OS"


### PR DESCRIPTION
For whatever reason `sudo launchctl start` wasn't enough when I tried using this on Darwin. The daemon would fail to launch and I'd get a socket failure.

This change got it working for me in the `pkgdb` repo.