### PR TITLE
feat: add `nix_install_url` param.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,12 @@ inputs:
     description: |
       Absolute installable URI to `flox` executable.
       Takes precedence over `floxpkgs-uri` setting.
+  nix_install_url:
+    description: |
+      URL for the `nix` installer to use.
+      This allows you to select alternative `nix` versions
+      from the list at https://releases.nixos.org/nix.
+    default: 'https://releases.nixos.org/nix/nix-2.15.2/install'
 
 
 runs:
@@ -50,6 +56,7 @@ runs:
     - uses: "cachix/install-nix-action@v22"
       if: "inputs.existing_nix != 'true'"
       with:
+        install_url: ${{ inputs.nix_install_url }}
         github_access_token: "${{ inputs.github-access-token }}"
         extra_nix_config: |
           experimental-features = nix-command flakes

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,9 @@ inputs:
     description: |
       URL for the `nix` installer to use.
       This allows you to select alternative `nix` versions
-      from the list at https://releases.nixos.org/nix.
+      from the list at https://releases.nixos.org/nix/.
+      To use the _latest_ stable release you may set this to
+      https://nixos.org/nix/install.
     default: 'https://releases.nixos.org/nix/nix-2.15.2/install'
 
 


### PR DESCRIPTION
This allows arbitrary versions of `nix` to be used by accepting the download URL for an installer to be passed in to the underlying `cachix/install-nix-action`.

It sets the default to v2.15.2 so that if the user doesn't explicitly specify a version their CI jobs won't "change unexpectedly" ( as they do with github:cachix/install-nix-action default of https://nixos.org/nix/install ).