### PR TITLE
`--stdin` flag for nix copy does not always exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - "fix-macos-cache"
       - "main"
       - "releases/*"
   schedule:

--- a/scripts/push-new-nix-store-paths.sh
+++ b/scripts/push-new-nix-store-paths.sh
@@ -26,4 +26,4 @@ fi
 echo "$NEW_STORE_PATHS_FILE_COUNT new paths will be pushed";
 
 # Allow pushing to fail.
-cat "$NEW_STORE_PATHS_FILE" | tr '\n' ' ' | nix copy --extra-experimental-features nix-command --to "$FLOX_SUBSTITUTER" --stdin -vv ||:;
+cat "$NEW_STORE_PATHS_FILE" | xargs -r nix copy --extra-experimental-features nix-command --to "$FLOX_SUBSTITUTER" -vv||:;


### PR DESCRIPTION
it is safer to use xargs