### PR TITLE
ci: run tests on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "Cache Dependencies"
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@8070854e57d983bdd2887b0a708ad985f77398ab
         env:
           GITHUB_ACTIONS_RUNNER_FORCED_NODE_VERSION: node20
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
         os:
           - "ubuntu-latest"
           - "macos-latest"
-          - [ self-hosted Linux ARM64 ]
-          - [ self-hosted Linux X86 ]
+          - [ "self-hosted", "Linux", "ARM64" ]
+          - [ "self-hosted", "Linux", "X86" ]
 
     steps:
       - name: "Checkout"
@@ -68,8 +68,8 @@ jobs:
         os:
           - "ubuntu-latest"
           - "macos-latest"
-          - [ self-hosted Linux ARM64 ]
-          - [ self-hosted Linux X86 ]
+          - [ "self-hosted", "Linux", "ARM64" ]
+          - [ "self-hosted", "Linux", "X86" ]
         # TODO: test with different flox versions
         #flox-version:
         #  - stable
@@ -102,8 +102,8 @@ jobs:
         os:
           - "ubuntu-latest"
           - "macos-latest"
-          - [ self-hosted Linux ARM64 ]
-          - [ self-hosted Linux X86 ]
+          - [ "self-hosted", "Linux", "ARM64" ]
+          - [ "self-hosted", "Linux", "X86" ]
         # TODO: test with different flox versions
         #flox-version:
         #  - stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
         os:
           - "ubuntu-latest"
           - "macos-latest"
-          - [ self-hosted linux arm64 ]
-          - [ self-hosted linux x86 ]
+          - [ self-hosted Linux ARM64 ]
+          - [ self-hosted Linux X86 ]
 
     steps:
       - name: "Checkout"
@@ -68,8 +68,8 @@ jobs:
         os:
           - "ubuntu-latest"
           - "macos-latest"
-          - [ self-hosted linux arm64 ]
-          - [ self-hosted linux x86 ]
+          - [ self-hosted Linux ARM64 ]
+          - [ self-hosted Linux X86 ]
         # TODO: test with different flox versions
         #flox-version:
         #  - stable
@@ -102,8 +102,8 @@ jobs:
         os:
           - "ubuntu-latest"
           - "macos-latest"
-          - [ self-hosted linux arm64 ]
-          - [ self-hosted linux x86 ]
+          - [ self-hosted Linux ARM64 ]
+          - [ self-hosted Linux X86 ]
         # TODO: test with different flox versions
         #flox-version:
         #  - stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           - "ubuntu-latest"
           - "macos-latest"
           - [ "self-hosted", "Linux", "ARM64" ]
-          - [ "self-hosted", "Linux", "X86" ]
+          - [ "self-hosted", "Linux", "X64" ]
 
     steps:
       - name: "Checkout"
@@ -71,7 +71,7 @@ jobs:
           - "ubuntu-latest"
           - "macos-latest"
           - [ "self-hosted", "Linux", "ARM64" ]
-          - [ "self-hosted", "Linux", "X86" ]
+          - [ "self-hosted", "Linux", "X64" ]
         # TODO: test with different flox versions
         #flox-version:
         #  - stable
@@ -105,7 +105,7 @@ jobs:
           - "ubuntu-latest"
           - "macos-latest"
           - [ "self-hosted", "Linux", "ARM64" ]
-          - [ "self-hosted", "Linux", "X86" ]
+          - [ "self-hosted", "Linux", "X64" ]
         # TODO: test with different flox versions
         #flox-version:
         #  - stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,15 @@ jobs:
 
   test-minimal-action:
     name: "Minimal - Github Action Test"
-    runs-on: "${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os:
           - "ubuntu-latest"
           - "macos-latest"
+          - [ self-hosted linux arm64 ]
+          - [ self-hosted linux x86 ]
         # TODO: test with different flox versions
         #flox-version:
         #  - stable
@@ -93,13 +95,15 @@ jobs:
 
   test-all-action:
     name: "All - Github Action Test"
-    runs-on: "${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os:
           - "ubuntu-latest"
           - "macos-latest"
+          - [ self-hosted linux arm64 ]
+          - [ self-hosted linux x86 ]
         # TODO: test with different flox versions
         #flox-version:
         #  - stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
       - name: "Cache Dependencies"
         id: cache
         uses: actions/cache@v3
+        env:
+          GITHUB_ACTIONS_RUNNER_FORCED_NODE_VERSION: node20
         with:
           key: npm-${{ matrix.os }}-${{ hashFiles('package-lock.json') }}
           path: ./node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,15 @@ jobs:
 
   test-javascript:
     name: "JavaScript Tests"
-    runs-on: "${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os:
           - "ubuntu-latest"
           - "macos-latest"
+          - [ self-hosted linux arm64 ]
+          - [ self-hosted linux x86 ]
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
Beginnings of allowing action on self-hosted (eg: NixOS) runners that do not have dpkg/apt/yum/etc.

Needed to include additional OS/arch/systems.