### PR TITLE
ci: reduce closure copied

### DIFF
--- a/scripts/push-new-nix-store-paths.sh
+++ b/scripts/push-new-nix-store-paths.sh
@@ -14,6 +14,8 @@ fi
 # https://www.haskellforall.com/2022/10/how-to-correctly-cache-build-time.html
 
 if [ -f /tmp/drv-paths ]; then
-	cat /tmp/drv-paths | xargs nix-store --query --requisites --include-outputs > /tmp/dependency-paths ||:;
-	cat /tmp/dependency-paths | awk '!seen[$0]++' | xargs nix copy --extra-experimental-features nix-command --to "$FLOX_SUBSTITUTER" ||:;
+	cat /tmp/drv-paths | xargs nix-store --query --requisites --include-outputs > /tmp/dependency-paths-outputs ||:;
+	cat /tmp/drv-paths | xargs nix-store --query --requisites  > /tmp/dependency-paths ||:;
+	# only copy the binary portions of the build-time dependencies
+	awk 'NR==FNR{a[$0]=1;next}!a[$0]' /tmp/dependency-paths /tmp/dependecy-paths-outputs | xargs nix copy --extra-experimental-features nix-command --to "$FLOX_SUBSTITUTER" ||:;
 fi


### PR DESCRIPTION
Only copy the binary outputs into the relevant cache. This avoids copying of all drv's and their outputs down to bootstrap.