### PR TITLE
feat: use cirrus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
-          - "macos-latest"
+          - "ghcr.io/cirruslabs/macos-sonoma-xcode:latest"
 
     steps:
       - name: "Checkout"
@@ -66,7 +66,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
-          - "macos-latest"
+          - "ghcr.io/cirruslabs/macos-sonoma-xcode:latest"
         # TODO: test with different flox versions
         #flox-version:
         #  - stable
@@ -93,7 +93,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
-          - "macos-latest"
+          - "ghcr.io/cirruslabs/macos-sonoma-xcode:latest"
 
     steps:
       - name: "Checkout"
@@ -145,7 +145,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
-          - "macos-latest"
+          - "ghcr.io/cirruslabs/macos-sonoma-xcode:latest"
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
update 2024-03-21: we can revisit this now that are past release and use cirrus for infrequent jobs