### PR TITLE
fix(ci): remove condtional from auto-label

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -9,13 +9,6 @@ on:
 jobs:
   add-label:
     runs-on: ubuntu-latest
-    if: |
-      github.actor == 'dependabot[bot]' ||
-      (
-        github.event.pull_request.author_association == 'MEMBER' ||
-        github.event.pull_request.author_association == 'OWNER' ||
-        github.event.pull_request.author_association == 'COLLABORATOR'
-      )
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
The conditional won't work for issues -- thinking we can just remove it, since it doesn't really matter if this runs for anyone.