### PR TITLE
feat: add installation retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ jobs:
 | `version` | Select a specific version from a channel | `""` |
 | `channel` | One of: `stable`, `qa`, `nightly`, or a commit hash | `"stable"` |
 | `disable-metrics` | Disable sending anonymous usage statistics to flox | `"false"` |
-| `download-retries` | Number of retries when downloading flox (for network resilience) | `"3"` |
+| `retries` | Number of retries for downloading and installing Flox | `"3"` |
 
 ### Example with custom inputs
 
@@ -89,7 +89,7 @@ jobs:
   uses: flox/install-flox-action@v2.1.0
   with:
     channel: nightly
-    download-retries: "5"
+    retries: "5"
 ```
 
 ## 🚀 Caching

--- a/action.yml
+++ b/action.yml
@@ -25,8 +25,8 @@ inputs:
     description: "Download base URL of flox installer"
     default: ""
 
-  download-retries:
-    description: "Number of retries when downloading flox (for network resilience)"
+  retries:
+    description: "Number of retries for downloading and installing Flox"
     default: "3"
 
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -26061,8 +26061,8 @@ async function getDownloadUrl() {
   const disable_metrics = core.getInput('disable-metrics')
   core.exportVariable('DISABLE_METRICS', disable_metrics)
 
-  const download_retries = core.getInput('download-retries') || '3'
-  core.exportVariable('DOWNLOAD_RETRIES', download_retries)
+  const retries = core.getInput('retries') || '3'
+  core.exportVariable('RETRIES', retries)
 
   let downloadUrl
 

--- a/src/main.js
+++ b/src/main.js
@@ -32,8 +32,8 @@ export async function getDownloadUrl() {
   const disable_metrics = core.getInput('disable-metrics')
   core.exportVariable('DISABLE_METRICS', disable_metrics)
 
-  const download_retries = core.getInput('download-retries') || '3'
-  core.exportVariable('DOWNLOAD_RETRIES', download_retries)
+  const retries = core.getInput('retries') || '3'
+  core.exportVariable('RETRIES', retries)
 
   let downloadUrl
 


### PR DESCRIPTION
## Summary

- Add retry loop around package installation (rpm, dpkg, installer)
- Rename `download-retries` input to `retries` since it now covers both download and install
- Uses same retry count for download and install (default: 3)
- 5 second delay between install retry attempts

## Context

This addresses flaky macOS installer failures like [this one](https://github.com/flox/floxhub/actions/runs/20996499121/job/60354588878?pr=765), where the download succeeds but the installation fails with:

```
installer: The install failed. (The Installer encountered an error that caused the installation to fail.)
```

The existing download retry logic didn't help because the failure occurred after the download completed successfully.