### PR TITLE
chore: ignore major version bumps for @actions/{core,exec}

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,11 @@ updates:
     all:
       patterns:
         - "*"
+  ignore:
+    - dependency-name: "@actions/core"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "@actions/exec"
+      update-types: ["version-update:semver-major"]
   labels:
     - "chore"
     - "team-developer-support"


### PR DESCRIPTION
Supersedes #174 
## Summary

- Adds Dependabot `ignore` rules to skip major version bumps for `@actions/core` and `@actions/exec`
- 3.x is ESM-only, which is incompatible with our CommonJS codebase, Jest mocking (`jest.mock` doesn't work with ESM), and `@vercel/ncc` bundler
- Minor/patch updates within 2.x will continue to be proposed
- Tracked in #176

## How we'll know when 2.x is EOL

When `@actions/core` 2.x is deprecated on npm:

- **npm install** will print a deprecation warning in CI and local output
- **GitHub dependency graph** will flag deprecated packages in the Dependabot security/alerts tab
- **Dependabot PRs** will show deprecation warnings on any 2.x PRs opened for other packages in the group
- **Security alerts** will still fire if a CVE is filed against 2.x, regardless of ignore rules

## Test plan

- [ ] Verify Dependabot picks up the `@actions/core` 2.0.2 → 2.0.3 bump
- [ ] Close the existing Dependabot PR for the 3.x bump