### PR TITLE
chore: pin GitHub Actions to SHA

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -14,7 +14,8 @@ jobs:
       issues: write
     steps:
     - name: Add team  label automatically to new issues and PRs
-      uses: actions-ecosystem/action-add-labels@v1
+      uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
+
       with:
         github_token: "${{ secrets.GITHUB_TOKEN }}"
         labels: "team-developer-support"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
 
       - name: "Install Flox"
         uses: "./"
@@ -74,7 +75,8 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
 
       - name: "Test Local Action"
         uses: "./"
@@ -108,7 +110,8 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
 
       - name: "Install Flox with new inputs"
         id: install
@@ -148,15 +151,18 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
 
       - name: "Install Nix (DeterminateSystems)"
         if: matrix.nix-installer == 'determinate-systems'
-        uses: "DeterminateSystems/nix-installer-action@main"
+        uses: DeterminateSystems/nix-installer-action@430608d219b9321ec0c98eb6c37245a39aa6756e # main
+
 
       - name: "Install Nix (Cachix)"
         if: matrix.nix-installer == 'cachix'
-        uses: "cachix/install-nix-action@v31"
+        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31
+
 
       - name: "Install Flox (using existing Nix)"
         uses: "./"
@@ -182,7 +188,8 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
 
       - name: "Install act"
         run: >-
@@ -220,7 +227,8 @@ jobs:
 
     steps:
       - name: "Slack Notification"
-        uses: "rtCamp/action-slack-notify@v2"
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
+
         env:
           SLACK_TITLE:      "Something broke CI for flox/flox on main"
           SLACK_FOOTER:     "Thank you for caring"

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -33,7 +33,8 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
 
       - name: "Install Flox"
         uses: "./"
@@ -49,7 +50,8 @@ jobs:
         run: git status
 
       - name: "Commit changes"
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
+
         with:
           file_pattern: "dist/index.js badges/coverage.svg"
           commit_message: "chore(deps): Update dist/"

--- a/.github/workflows/update-flox-env.yml
+++ b/.github/workflows/update-flox-env.yml
@@ -14,18 +14,21 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
         with:
           fetch-depth: 0
 
       - name: "Install Flox"
-        uses: flox/install-flox-action@v2.3.0
+        uses: flox/install-flox-action@9428713e8d3883274c334b4b95b8830beebd24d2 # v2.3.0
+
 
       - name: "Update Flox Environment"
         run: flox update
 
       - name: "Create Pull Request"
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
+
         with:
           token: ${{ secrets.MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}
           commit-message: "chore: update flox environment"


### PR DESCRIPTION
## Summary

Pin all external action references to immutable commit SHAs to mitigate supply chain attacks.

## Test plan

- [ ] CI passes

Tracking: https://github.com/flox/product/issues/1302