### PR TITLE
ci: add ubuntu-slim runner to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
+          - "ubuntu-slim"
           - "macos-latest"
 
     steps:
@@ -85,10 +86,12 @@ jobs:
           channel: "${{ matrix.release-env }}"
           disable-metrics: true
 
-
-      - name: "Test: flox --version"
+      - name: "Test: flox"
         run: |
           flox --version
+          flox init
+          flox install hello
+          flox activate -- hello
 
       - name: "Test: flox config"
         run: |
@@ -136,6 +139,13 @@ jobs:
           flox config --list | grep -q 'disable_metrics = true'
           flox config --list | grep -q 'upgrade_notifications = false'
 
+      - name: "Test: flox"
+        run: |
+          flox --version
+          flox init
+          flox install hello
+          flox activate -- hello
+
   test-existing-nix:
     name: "Test with Existing Nix (${{ matrix.nix-installer }})"
     runs-on: ${{ matrix.os }}
@@ -172,9 +182,12 @@ jobs:
         with:
           disable-metrics: true
 
-      - name: "Test: flox --version"
+      - name: "Test: flox"
         run: |
           flox --version
+          flox init
+          flox install hello
+          flox activate -- hello
 
       - name: "Test: flox config"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
 
   test-act:
     name: "Test with nektos/act"
-    runs-on: "ubuntu-slim"
+    runs-on: "ubuntu-latest"
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
       - name: "Test: flox"
         run: |
           flox --version
+          cd $(mktemp -d)
           flox init
           flox install hello
           flox activate -- hello
@@ -142,6 +143,7 @@ jobs:
       - name: "Test: flox"
         run: |
           flox --version
+          cd $(mktemp -d)
           flox init
           flox install hello
           flox activate -- hello
@@ -185,6 +187,7 @@ jobs:
       - name: "Test: flox"
         run: |
           flox --version
+          cd $(mktemp -d)
           flox init
           flox install hello
           flox activate -- hello

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
+          - "ubuntu-slim"
           - "macos-latest"
         release-env:
           - stable
@@ -106,6 +107,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
+          - "ubuntu-slim"
           - "macos-latest"
 
     steps:
@@ -144,6 +146,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
+          - "ubuntu-slim"
           - "macos-latest"
         nix-installer:
           - "determinate-systems"
@@ -183,7 +186,7 @@ jobs:
 
   test-act:
     name: "Test with nektos/act"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     timeout-minutes: 30
 
     steps:
@@ -213,7 +216,7 @@ jobs:
 
   report-failure:
     name: "Report Failure"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     timeout-minutes: 30
 
     if: ${{ failure() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule') }}

--- a/scripts/install-flox.sh
+++ b/scripts/install-flox.sh
@@ -90,3 +90,15 @@ done
 if [[ -z "${PRESERVE_DOWNLOAD:-}" ]]; then
   rm "$DOWNLOADED_FILE"
 fi
+
+# In environments without systemd (e.g. ubuntu-slim containers), flox's
+# postinst falls back to single-user Nix but still chowns /nix to
+# root:nixbld, leaving the unprivileged runner user unable to access
+# /nix/var/nix/db. In single-user mode the current user must own /nix.
+if [ "$(uname -s)" = "Linux" ] \
+   && [ "${EUID:-$(id -u)}" -ne 0 ] \
+   && [ -f /etc/nix/nix.conf ] \
+   && grep -qE '^build-users-group[[:space:]]*=[[:space:]]*$' /etc/nix/nix.conf; then
+  echo "Single-user Nix detected; taking ownership of /nix for uid=$(id -u)"
+  $SUDO chown -R "$(id -u):$(id -g)" /nix
+fi

--- a/scripts/install-flox.sh
+++ b/scripts/install-flox.sh
@@ -95,10 +95,10 @@ fi
 # postinst falls back to single-user Nix but still chowns /nix to
 # root:nixbld, leaving the unprivileged runner user unable to access
 # /nix/var/nix/db. In single-user mode the current user must own /nix.
+# Detect systemd the same way flox's own postinst does: PID 1 is systemd.
 if [ "$(uname -s)" = "Linux" ] \
    && [ "${EUID:-$(id -u)}" -ne 0 ] \
-   && [ -f /etc/nix/nix.conf ] \
-   && grep -qE '^build-users-group[[:space:]]*=[[:space:]]*$' /etc/nix/nix.conf; then
-  echo "Single-user Nix detected; taking ownership of /nix for uid=$(id -u)"
+   && [ "$(cat /proc/1/comm 2>/dev/null)" != "systemd" ]; then
+  echo "Single-user Nix detected (no systemd); taking ownership of /nix for uid=$(id -u)"
   $SUDO chown -R "$(id -u):$(id -g)" /nix
 fi


### PR DESCRIPTION
## Summary

- Add `ubuntu-slim` to the matrix in `test-javascript`, `test-action`, `test-new-inputs`, and `test-existing-nix` so the action is exercised on slim runners alongside `ubuntu-latest` and `macos-latest`.
- Switch `test-act` and `report-failure` jobs to `ubuntu-slim`.
- Verify flox actually runs end-to-end (`flox --version`, `flox init`, `flox install hello`, `flox activate -- hello`) in `test-action`, `test-new-inputs`, and `test-existing-nix` to catch runtime regressions, not just install-time success.

## Test plan

- [ ] CI matrix expands with `ubuntu-slim` jobs and they pass.
- [ ] End-to-end `flox init` + `flox install hello` + `flox activate -- hello` succeeds across all matrix combinations.
- [ ] `test-act` still completes successfully on the slim runner.
- [ ] `report-failure` still triggers correctly on main when other jobs fail.