### PR TITLE
chore: rename action to "Install Flox"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: "Install flox"
-description: "Installs flox on GitHub Actions for the supported platforms: GNU/Linux and macOS."
-author: "flox <hello@floxdev.com>"
+name: "Install Flox"
+description: "Install Flox on GitHub Actions runners for GNU/Linux and macOS"
+author: "Flox <hello@flox.dev>"
 
 branding:
   color: "blue"


### PR DESCRIPTION
## Summary

Update the action's Marketplace metadata in preparation for publication:

- Rename the display name to `"Install Flox"`, capitalizing the Flox brand (the lowercase `flox` is reserved for CLI invocation).
- Rewrite the description in imperative voice (matching the sibling `activate-action`) with brand-consistent capitalization and no trailing period, per Marketplace description conventions.
- Capitalize `Flox` in the `author:` field and update the email from the outdated `floxdev.com` domain to `flox.dev`.

This is a metadata-only change. The `name:`, `description:`, and `author:` fields control the action's appearance on the Marketplace listing; they do not affect how consumers reference the action (`flox/install-flox-action@<ref>`). Existing workflows continue to work without modification.

The brand-first form `"Flox Install"` was considered for parallelism with `"Flox Activate"` (the sibling action's new name) but rejected: `flox install` is itself a CLI subcommand for adding packages to a Flox environment, so the brand-first form would conflate the action's purpose with an unrelated CLI operation. `"Install Flox"` reads naturally and matches the repo slug.

Part of [ECO-60](https://linear.app/floxdotdev/issue/ECO-60/get-flox-github-actions-verified-by-github).

### Test plan

- [x] CI passes
- [ ] Visually confirm rendered name and description on the GitHub Marketplace listing preview when drafting a release