### PR TITLE
docs: capitalize Flox brand and use major-version pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
   </a>
 </p>
 
-Installs [flox][flox-github] on GitHub Actions for the supported platforms:
+Installs [Flox][flox-github] on GitHub Actions for the supported platforms:
 Linux and macOS. Available on the [GitHub Marketplace][marketplace].
 
 [Flox][flox-website] is a virtual environment and package manager all in one. With Flox you 
@@ -63,14 +63,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Install flox
-      uses: flox/install-flox-action@v2.2.0
+      - name: Install Flox
+        uses: flox/install-flox-action@v2
 
-    - name: Build
-      run: flox build
+      - name: Build
+        run: flox build
 ```
 
 ## ⚙️ Inputs
@@ -102,8 +102,8 @@ jobs:
 ### Example with custom inputs
 
 ```yml
-- name: Install flox
-  uses: flox/install-flox-action@v2.2.0
+- name: Install Flox
+  uses: flox/install-flox-action@v2
   with:
     channel: nightly
     retries: "5"
@@ -112,8 +112,8 @@ jobs:
 ### Example with extra substituters
 
 ```yml
-- name: Install flox
-  uses: flox/install-flox-action@v2.2.0
+- name: Install Flox
+  uses: flox/install-flox-action@v2
   with:
     extra-substituters: "https://my-cache.example.com"
     extra-substituter-keys: "my-cache.example.com-1:abc123..."
@@ -130,8 +130,8 @@ The downloaded flox installer package (`.deb`/`.rpm`/`.pkg`) is cached by defaul
 To disable caching:
 
 ```yml
-- name: Install flox
-  uses: flox/install-flox-action@v2.2.0
+- name: Install Flox
+  uses: flox/install-flox-action@v2
   with:
     use-cache: "false"
 ```


### PR DESCRIPTION
## Summary

Three small corrective fixes to `README.md`:

- Capitalize the Flox brand in the intro and example step names. The lowercase `flox` form is reserved for CLI invocation; the brand on product surfaces should be `Flox`. Matches the renamed `action.yml` display name.
- Pin code samples to the major-version tag (`@v2`) instead of a specific minor (`@v2.2.0`, now stale). The major-version pattern lets readers track the latest within v2 without rewriting their workflows on every minor release.
- Indent the step items under `steps:` in the Getting Started example by two spaces. The compact form is technically valid YAML, but the indented form is the more common convention and friendlier to copy-paste into editors with strict linting. Mirrors the equivalent change in `flox/activate-action`.

Part of [ECO-60](https://linear.app/floxdotdev/issue/ECO-60/get-flox-github-actions-verified-by-github) (follow-up README hygiene from the rename work).

### Test plan

- [x] CI passes
- [x] README renders cleanly on the repo page