### PR TITLE
feat: make job summary opt-in via `write-summary` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ jobs:
 | `extra-substituter-keys` | Space-separated public keys for extra substituters | `""` |
 | `proxy` | HTTP/HTTPS/SOCKS5 proxy URL for network requests | `""` |
 | `disable-upgrade-notifications` | Suppress flox upgrade notifications in CI output | `"true"` |
+| `write-summary` | Write a Flox installation summary to the job summary page | `"false"` |
 | `extra-flox-config` | Key=value pairs for `flox config --set`, one per line | `""` |
 
 ## 📤 Outputs

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,13 @@ inputs:
       Suppress flox upgrade notifications in CI output.
     default: "true"
 
+  write-summary:
+    description: >-
+      Write a Flox installation summary table to the GitHub Actions
+      job summary ($GITHUB_STEP_SUMMARY). Off by default to avoid
+      cluttering summaries used for other output.
+    default: "false"
+
   extra-flox-config:
     description: >-
       Additional flox config key=value pairs, one per

--- a/src/main.js
+++ b/src/main.js
@@ -330,14 +330,16 @@ export async function run() {
     await captureOutputs(nixDetected)
     core.endGroup()
 
-    await writeJobSummary({
-      floxVersion: core.getInput('version') || '(latest)',
-      channel: core.getInput('channel') || 'stable',
-      method: nixDetected ? 'nix profile' : 'package',
-      platform: process.platform,
-      arch: process.arch,
-      nixDetected
-    })
+    if (core.getInput('write-summary') === 'true') {
+      await writeJobSummary({
+        floxVersion: core.getInput('version') || '(latest)',
+        channel: core.getInput('channel') || 'stable',
+        method: nixDetected ? 'nix profile' : 'package',
+        platform: process.platform,
+        arch: process.arch,
+        nixDetected
+      })
+    }
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -226,6 +226,66 @@ describe('main', () => {
 
       expect(core.setFailed).toHaveBeenCalledWith('something went wrong')
     })
+
+    it('does not write the job summary by default', async () => {
+      which.mockImplementation(cmd => {
+        if (cmd === 'nix') return Promise.resolve(null)
+        if (cmd === 'flox') return Promise.resolve('/usr/local/bin/flox')
+        return Promise.resolve(null)
+      })
+      core.getInput.mockImplementation(name => {
+        if (name === 'channel') return 'stable'
+        if (name === 'disable-upgrade-notifications') return 'true'
+        return ''
+      })
+      exec.exec.mockImplementation(async (cmd, args, opts) => {
+        if (
+          cmd === 'flox' &&
+          args &&
+          args[0] === '--version' &&
+          opts &&
+          opts.listeners
+        ) {
+          opts.listeners.stdout(Buffer.from('flox 1.7.6\n'))
+        }
+        return 0
+      })
+
+      await main.run()
+
+      expect(core.summary.write).not.toHaveBeenCalled()
+    })
+
+    it('writes the job summary when write-summary is true', async () => {
+      which.mockImplementation(cmd => {
+        if (cmd === 'nix') return Promise.resolve(null)
+        if (cmd === 'flox') return Promise.resolve('/usr/local/bin/flox')
+        return Promise.resolve(null)
+      })
+      core.getInput.mockImplementation(name => {
+        if (name === 'channel') return 'stable'
+        if (name === 'disable-upgrade-notifications') return 'true'
+        if (name === 'write-summary') return 'true'
+        return ''
+      })
+      exec.exec.mockImplementation(async (cmd, args, opts) => {
+        if (
+          cmd === 'flox' &&
+          args &&
+          args[0] === '--version' &&
+          opts &&
+          opts.listeners
+        ) {
+          opts.listeners.stdout(Buffer.from('flox 1.7.6\n'))
+        }
+        return 0
+      })
+
+      await main.run()
+
+      expect(core.summary.addHeading).toHaveBeenCalledWith('Flox Installation')
+      expect(core.summary.write).toHaveBeenCalled()
+    })
   })
 
   describe('configureNixSubstituter', () => {


### PR DESCRIPTION
## Summary

The action wrote a "Flox Installation" table to `$GITHUB_STEP_SUMMARY` after every install. That table is useful in many workflows, but it is noise in jobs that use the GitHub Actions job summary for their own output, such as Terraform or Terragrunt plan results, where it makes the summary read as partly about Flox rather than only about the job's own result.

This adds a `write-summary` input that gates the summary table. It defaults to `false`, so the summary is now opt-in: callers that want the table set `write-summary: true`. The previously circulated workaround of overriding `GITHUB_STEP_SUMMARY` to `/dev/null` for the step is no longer necessary.

Fixes #200.
Fixes [CLI-48](https://linear.app/floxdotdev/issue/CLI-48).

### Behavior change

This flips the previous always-on behavior. Existing consumers will no longer see the installation summary unless they opt in:

```yaml
- uses: flox/install-flox-action@v2
  with:
    write-summary: true
```

The change is additive (a new input) and the behavior shift is cosmetic; no outputs, inputs, or workflow logic depend on the summary. It is therefore intended to ship as a minor release (`v2.5.0`), with the default flip called out in the release notes so anyone relying on the summary knows how to restore it.

### Test plan

- [x] `npm run all` (Prettier check, Jest, `ncc` package) passes locally
- [x] Unit tests cover both paths: the summary is not written by default, and is written when `write-summary` is `true`
- [x] `dist/index.js` regenerated; the gate is present in the bundle
- [ ] CI end-to-end install across Ubuntu and macOS still succeeds, with a summary appearing only when `write-summary: true`