### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+## Validation
+
+- [ ] I ran `npm test` or the relevant local check.
+- [ ] I updated documentation or examples if needed.
+
+## Release notes
+
+- [ ] This change should be mentioned in release notes.
+- [ ] This change does not need release notes.
+
+## Reviewer notes
+
+Add any context maintainers should know.


### PR DESCRIPTION
Adds a small `.github/PULL_REQUEST_TEMPLATE.md` so contributors include a summary, validation notes, release-note impact, and reviewer context.

This follows up on #204 and is intentionally limited to one maintainer-readiness file.