### PR TITLE
fix(metrics): FLOX_DISABLE_METRICS not honoured

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ jobs:
 |-------|-------------|---------|
 | `version` | Select a specific version from a channel | `""` |
 | `channel` | One of: `stable`, `qa`, `nightly`, or a commit hash | `"stable"` |
-| `disable-metrics` | Disable sending anonymous usage statistics to flox | `"false"` |
+| `disable-metrics` | Disable sending anonymous usage statistics to flox | `""` |
 | `retries` | Number of retries for downloading and installing Flox | `"3"` |
 | `use-cache` | Cache the downloaded flox package to speed up subsequent runs | `"true"` |
 | `github-token` | GitHub token for Nix flake rate limiting | `${{ github.token }}` |

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,11 @@ inputs:
     default: "stable"
 
   disable-metrics:
-    description: "Disable sending anonymous usage statistics to flox"
-    default: "false"
+    description: >-
+      Disable sending anonymous usage statistics to flox.
+      When unset, honors the FLOX_DISABLE_METRICS env var
+      (or the CLI default if neither is set).
+    default: ""
 
   base-url:
     deprecationMessage: "Please use channel option"

--- a/package-lock.json
+++ b/package-lock.json
@@ -316,6 +316,7 @@
       "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -539,6 +540,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3561,6 +3563,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",

--- a/src/main.js
+++ b/src/main.js
@@ -35,9 +35,6 @@ export async function getDownloadUrl() {
     version = '-' + core.getInput('version')
   }
 
-  const disable_metrics = core.getInput('disable-metrics')
-  core.exportVariable('FLOX_DISABLE_METRICS', disable_metrics)
-
   const retries = core.getInput('retries') || '3'
   core.exportVariable('RETRIES', retries)
 

--- a/src/main.js
+++ b/src/main.js
@@ -280,7 +280,9 @@ export async function writeJobSummary({
 export async function run() {
   try {
     const disable_metrics = core.getInput('disable-metrics')
-    core.exportVariable('FLOX_DISABLE_METRICS', disable_metrics)
+    if (disable_metrics !== '') {
+      core.exportVariable('FLOX_DISABLE_METRICS', disable_metrics)
+    }
 
     core.startGroup('Download & Install flox')
     const nix = await which('nix', { nothrow: true })

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -917,3 +917,84 @@ describe('main', () => {
     })
   })
 })
+
+describe('run disable-metrics guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    core.getInput.mockReturnValue('')
+    core.summary = {
+      addHeading: jest.fn().mockReturnThis(),
+      addTable: jest.fn().mockReturnThis(),
+      write: jest.fn().mockResolvedValue(undefined)
+    }
+  })
+
+  it('does not export FLOX_DISABLE_METRICS in run() when disable-metrics input is unset', async () => {
+    which.mockImplementation(cmd => {
+      if (cmd === 'nix')
+        return Promise.resolve('/nix/var/nix/profiles/default/bin/nix')
+      if (cmd === 'flox') return Promise.resolve('/usr/local/bin/flox')
+      return Promise.resolve(null)
+    })
+    core.getInput.mockImplementation(name => {
+      if (name === 'disable-upgrade-notifications') return 'true'
+      return ''
+    })
+    fs.existsSync.mockReturnValue(true)
+    fs.readFileSync.mockReturnValue('')
+    exec.exec.mockImplementation(async (cmd, args, opts) => {
+      if (
+        cmd === 'flox' &&
+        args &&
+        args[0] === '--version' &&
+        opts &&
+        opts.listeners
+      ) {
+        opts.listeners.stdout(Buffer.from('flox 1.7.6\n'))
+      }
+      return 0
+    })
+
+    await main.run()
+
+    expect(core.exportVariable).not.toHaveBeenCalledWith(
+      'FLOX_DISABLE_METRICS',
+      expect.anything()
+    )
+  })
+
+  it('exports FLOX_DISABLE_METRICS in run() when disable-metrics input is explicitly set', async () => {
+    which.mockImplementation(cmd => {
+      if (cmd === 'nix')
+        return Promise.resolve('/nix/var/nix/profiles/default/bin/nix')
+      if (cmd === 'flox') return Promise.resolve('/usr/local/bin/flox')
+      return Promise.resolve(null)
+    })
+    core.getInput.mockImplementation(name => {
+      if (name === 'disable-metrics') return 'true'
+      if (name === 'disable-upgrade-notifications') return 'true'
+      return ''
+    })
+    fs.existsSync.mockReturnValue(true)
+    fs.readFileSync.mockReturnValue('')
+    exec.exec.mockImplementation(async (cmd, args, opts) => {
+      if (
+        cmd === 'flox' &&
+        args &&
+        args[0] === '--version' &&
+        opts &&
+        opts.listeners
+      ) {
+        opts.listeners.stdout(Buffer.from('flox 1.7.6\n'))
+      }
+      return 0
+    })
+
+    await main.run()
+
+    expect(core.exportVariable).toHaveBeenCalledWith(
+      'FLOX_DISABLE_METRICS',
+      'true'
+    )
+  })
+})

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -901,11 +901,10 @@ describe('main', () => {
       )
     })
 
-    it('exports FLOX_DISABLE_METRICS and RETRIES env vars', async () => {
+    it('exports RETRIES env var', async () => {
       Object.defineProperty(process, 'platform', { value: 'darwin' })
       Object.defineProperty(process, 'arch', { value: 'arm64' })
       core.getInput.mockImplementation(name => {
-        if (name === 'disable-metrics') return 'true'
         if (name === 'retries') return '5'
         if (name === 'channel') return 'stable'
         return ''
@@ -914,10 +913,6 @@ describe('main', () => {
 
       await main.getDownloadUrl()
 
-      expect(core.exportVariable).toHaveBeenCalledWith(
-        'FLOX_DISABLE_METRICS',
-        'true'
-      )
       expect(core.exportVariable).toHaveBeenCalledWith('RETRIES', '5')
     })
   })


### PR DESCRIPTION
**refactor(metrics): FLOX_DISABLE_METRICS dupe set**

The action's sole entry point is `run()` (`action.yml` declares only
`main: dist/index.js`), and `run()` exports `FLOX_DISABLE_METRICS` at the top
of every invocation — before the nix/package branch — so it already covers
every install path. `getDownloadUrl()` is reached only on the package path,
and always after `run()` has exported the same value, so its own
`FLOX_DISABLE_METRICS` export was dead duplication left behind when the
export was hoisted into `run()`.

Remove that export so there is a single source of truth. No behavior change:
`run()` still exports unconditionally here — the guard that fixes the
workflow-env override bug lands in the following commit. `getDownloadUrl()`
keeps its `RETRIES`/`PROXY` exports, which are specific to the package path,
and its test is narrowed to the RETRIES assertion it still covers.

**fix(metrics): FLOX_DISABLE_METRICS conditional**

Callers who set `FLOX_DISABLE_METRICS: "true"` at the workflow `env:` level
were silently having their setting overwritten. The `disable-metrics` input
defaulted to `"false"`, and `core.exportVariable` writes to `$GITHUB_ENV`,
which the runner folds into the job's global environment — overwriting any
prior value. This meant the obvious way to opt out of metrics was broken.

Guard the single `run()` export so it only fires when the caller actually
passes the input. When `disable-metrics` is unset (the new default of `""`),
the action leaves `FLOX_DISABLE_METRICS` untouched — at whatever value the
caller already set, or absent, in which case the flox CLI applies its own
default (disabled/false by its `#[serde(default)]` bool).

`action.yml` default changed from `"false"` to `""` and the description
expanded to explain the new semantics. `README.md` inputs table updated to
match. `dist/index.js` rebuilt to match.

Tests cover both branches of the `run()` guard: an unset input leaves
`FLOX_DISABLE_METRICS` untouched (the regression), and an explicit value is
still exported. 64 tests pass, statement/line coverage at 100%.

--

I'll cut a release and bump our usage once this is merged.